### PR TITLE
fix(time format): fix order time format

### DIFF
--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -20,6 +20,10 @@ class ViewOrders extends Component {
             });
     }
 
+    formatDigits(n) {
+        return ( n < 10 ? '0' : '' ) + n;
+    }
+
     render() {
         return (
             <Template>
@@ -33,7 +37,7 @@ class ViewOrders extends Component {
                                     <p>Ordered by: {order.ordered_by || ''}</p>
                                 </div>
                                 <div className="col-md-4 d-flex view-order-middle-col">
-                                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
+                                    <p>Order placed at {`${this.formatDigits(createdDate.getHours())}:${this.formatDigits(createdDate.getMinutes())}:${this.formatDigits(createdDate.getSeconds())}`}</p>
                                     <p>Quantity: {order.quantity}</p>
                                  </div>
                                  <div className="col-md-4 view-order-right-col">


### PR DESCRIPTION
## Changes
1. Added function called formatDigits which always returns a two-digit number
2. Applied the function to hours, seconds, and minutes in render

## Purpose
Order Time should be correctly formatted in hh:mm:ss format.

## Approach
The dates will now include six digits at all times

## Learning
1. Researched best practices, didn't find what I was looking for. 
2. Read through MDN to understand more about Date() and Time() get methods
3. Decided easiest solution was write a short function to format each number 

inspiration for the simplest function:
https://electrictoolbox.com/pad-number-two-digits-javascript/

_If this closes an issue, reference the issue here. If it doesn't, remove this line_
Closes #30