### PR TITLE
fix(fetch_email): redux is now saving user email with correct variabl…

### DIFF
--- a/application/src/redux/reducers/authReducer.js
+++ b/application/src/redux/reducers/authReducer.js
@@ -5,7 +5,7 @@ const INITIAL_STATE = { email: null, token: null };
 export default (state = INITIAL_STATE, action) => {
     switch (action.type) {
         case LOGIN:
-            return { ...state, email: action.payload.login, token: action.payload.token }
+            return { ...state, email: action.payload.email, token: action.payload.token }
         case LOGOUT:
             return { ...state, ...INITIAL_STATE }
         default:


### PR DESCRIPTION
…e at login

## Changes
replaced undefined variable 'login' with 'email' in authReducer

## Purpose
The login should be storing the login response in redux, and then grabbing that info to be stored in the order. Login response is a success, but the email is not properly being added.

## Approach
Checked for error in viewOrders - found the variable ordered_by but returning undefined
Checked for error in orderForm - found there was no user email to save with the order
Checked authReducer and used logs to determine variable '...auth.login' should be '...auth.email'

Closes #17